### PR TITLE
Allow using filesystems that does not reside on a partition

### DIFF
--- a/ansible.vmdb
+++ b/ansible.vmdb
@@ -16,9 +16,9 @@ steps:
 
   - mkfs: ext4
     partition: root-part
-
-  - mount: root-part
     fs-tag: root-fs
+
+  - mount: root-fs
 
   - unpack-rootfs: root-fs
 

--- a/pc.vmdb
+++ b/pc.vmdb
@@ -16,9 +16,9 @@ steps:
 
   - mkfs: ext4
     partition: root-part
-
-  - mount: root-part
     fs-tag: root-fs
+
+  - mount: root-fs
 
   - unpack-rootfs: root-fs
 

--- a/simple.yaml
+++ b/simple.yaml
@@ -13,9 +13,9 @@ steps:
 
   - mkfs: ext4
     partition: root-part
-
-  - mount: root-part
     fs-tag: root-fs
+
+  - mount: root-fs
 
   - debootstrap: stretch
     mirror: http://http.debian.net/debian

--- a/smoke-pc.vmdb
+++ b/smoke-pc.vmdb
@@ -13,9 +13,9 @@ steps:
 
   - mkfs: ext4
     partition: root-part
-
-  - mount: root-part
     fs-tag: root-fs
+
+  - mount: root-fs
 
   - unpack-rootfs: root-fs
 

--- a/uefi.vmdb
+++ b/uefi.vmdb
@@ -25,9 +25,9 @@ steps:
 
   - mkfs: ext4
     partition: root-part
-
-  - mount: root-part
     fs-tag: root-fs
+
+  - mount: root-fs
 
   - unpack-rootfs: root-fs
 

--- a/vmdb/plugins/mkfs_plugin.py
+++ b/vmdb/plugins/mkfs_plugin.py
@@ -35,6 +35,7 @@ class MkfsStepRunner(vmdb.StepRunnerInterface):
 
     def run(self, step, settings, state):
         fstype = step['mkfs']
+        fs_tag = step['fs-tag']
 
         if not (('device' in step) ^ ('partition' in step)):
             raise AttributeError('You must provide device or partition, and only one of them')
@@ -50,3 +51,7 @@ class MkfsStepRunner(vmdb.StepRunnerInterface):
         vmdb.progress(
             'Creating {} filesystem on {}'.format(fstype, device_file))
         vmdb.runcmd(['/sbin/mkfs', '-t', fstype, device_file])
+
+        filesystems = getattr(state, 'filesystems', {})
+        filesystems[fs_tag] = device_file
+        state.filesystems = filesystems

--- a/vmdb/plugins/mkfs_plugin.py
+++ b/vmdb/plugins/mkfs_plugin.py
@@ -31,12 +31,22 @@ class MkfsPlugin(cliapp.Plugin):
 class MkfsStepRunner(vmdb.StepRunnerInterface):
 
     def get_required_keys(self):
-        return ['mkfs', 'partition']
+        return ['mkfs']
 
     def run(self, step, settings, state):
         fstype = step['mkfs']
-        part_tag = step['partition']
-        device = state.parts[part_tag]
+
+        if not (('device' in step) ^ ('partition' in step)):
+            raise AttributeError('You must provide device or partition, and only one of them')
+
+        device_file = None
+        if 'device' in step:
+            device_file = step['device']
+        else:
+            part_tag = step['partition']
+            device_file = state.parts[part_tag]
+
+        assert device_file is not None
         vmdb.progress(
-            'Creating {} filesystem on {}'.format(fstype, device))
-        vmdb.runcmd(['/sbin/mkfs', '-t', fstype, device])
+            'Creating {} filesystem on {}'.format(fstype, device_file))
+        vmdb.runcmd(['/sbin/mkfs', '-t', fstype, device_file])

--- a/vmdb/plugins/mount_plugin.py
+++ b/vmdb/plugins/mount_plugin.py
@@ -34,7 +34,7 @@ class MountPlugin(cliapp.Plugin):
 class MountStepRunner(vmdb.StepRunnerInterface):
 
     def get_required_keys(self):
-        return ['mount', 'fs-tag']
+        return ['mount']
 
     def run(self, step, settings, state):
         self.mount_rootfs(step, settings, state)
@@ -46,13 +46,12 @@ class MountStepRunner(vmdb.StepRunnerInterface):
         if not hasattr(state, 'mounts'):
             state.mounts = {}
 
-        part_tag = step['mount']
-        fs_tag = step['fs-tag']
+        fs_tag = step['mount']
         dirname = step.get('dirname')
         mount_on = step.get('mount-on')
 
         if fs_tag in state.mounts:
-            raise Exception('fs-tag {} already used'.format(fs_tag))
+            raise Exception('fs {} already mounted'.format(fs_tag))
 
         if dirname:
             if not mount_on:
@@ -69,7 +68,7 @@ class MountStepRunner(vmdb.StepRunnerInterface):
         else:
             mount_point = tempfile.mkdtemp()
 
-        device = state.parts[part_tag]
+        device = state.filesystems[fs_tag]
 
         vmdb.runcmd(['mount', device, mount_point])
         state.mounts[fs_tag] = mount_point
@@ -77,7 +76,7 @@ class MountStepRunner(vmdb.StepRunnerInterface):
         return mount_point
 
     def unmount_rootfs(self, step, settings, state):
-        fs_tag = step['fs-tag']
+        fs_tag = step['mount']
         mount_point = state.mounts[fs_tag]
 
         vmdb.runcmd(['umount', mount_point])


### PR DESCRIPTION
When creating an image to be used as the rootfs for a container, one does not want to have a partition table in the image but use it as a filesystem directly.
vmdb2 does not support this, because it only allows the creation of filesystems on partitions but not on the output image itself.

I fixed this by extending the `mkfs` step to take either a `partition` or a `device` parameter.
One can then set `device: "{{ output }}"` to format the image.

I also moved the creation of `fs-tag` from the `mount` step to the `mkfs` step.
Since a filesystem can be mounted only once, I think this is the better place.
It also allows to pass the `fs-tag` to the `mount` step (and subsequent steps, too).
Otherwise we would need another tag for the filesystem, that can be passed to the `mount` step if a filesystem does not reside on a partition.