### PR TITLE
Replace http.debian.net with deb.debian.org

### DIFF
--- a/ansible.vmdb
+++ b/ansible.vmdb
@@ -23,7 +23,7 @@ steps:
   - unpack-rootfs: root-fs
 
   - debootstrap: stretch
-    mirror: http://http.debian.net/debian
+    mirror: http://deb.debian.org/debian
     target: root-fs
     unless: rootfs_unpacked
 

--- a/doc/en/000.mdwn
+++ b/doc/en/000.mdwn
@@ -75,7 +75,7 @@ steps:
   - unpack-rootfs: root-fs
 
   - debootstrap: stretch
-    mirror: http://http.debian.net/debian
+    mirror: http://deb.debian.org/debian
     target: root-fs
     unless: rootfs_unpacked
 

--- a/pc.vmdb
+++ b/pc.vmdb
@@ -23,7 +23,7 @@ steps:
   - unpack-rootfs: root-fs
 
   - debootstrap: stretch
-    mirror: http://http.debian.net/debian
+    mirror: http://deb.debian.org/debian
     target: root-fs
     unless: rootfs_unpacked
 

--- a/simple.yaml
+++ b/simple.yaml
@@ -18,7 +18,7 @@ steps:
     fs-tag: root-fs
 
   - debootstrap: stretch
-    mirror: http://http.debian.net/debian
+    mirror: http://deb.debian.org/debian
     target: root-fs
 
   - apt: linux-image-amd64

--- a/smoke-pc.vmdb
+++ b/smoke-pc.vmdb
@@ -20,7 +20,7 @@ steps:
   - unpack-rootfs: root-fs
 
   - debootstrap: stretch
-    mirror: http://http.debian.net/debian
+    mirror: http://deb.debian.org/debian
     target: root-fs
     unless: rootfs_unpacked
 

--- a/uefi.vmdb
+++ b/uefi.vmdb
@@ -32,7 +32,7 @@ steps:
   - unpack-rootfs: root-fs
 
   - debootstrap: stretch
-    mirror: http://http.debian.net/debian
+    mirror: http://deb.debian.org/debian
     target: root-fs
     unless: rootfs_unpacked
 


### PR DESCRIPTION
The latter is provided by DSA and uses CDNs instead of HTTP redirects.

AIUI, deb.debian.org is considered more stable and preferred over the older
http.debian.net.