### PR TITLE
consistently call parted with -s

### DIFF
--- a/vmdb/plugins/partition_plugin.py
+++ b/vmdb/plugins/partition_plugin.py
@@ -39,7 +39,7 @@ class MklabelStepRunner(vmdb.StepRunnerInterface):
         device = step['device']
         vmdb.progress(
             'Creating partition table ({}) on {}'.format(label_type, device))
-        vmdb.runcmd(['parted', device, 'mklabel', label_type])
+        vmdb.runcmd(['parted', '-s', device, 'mklabel', label_type])
         state.parts = {}
 
 


### PR DESCRIPTION
This fixes an endless hang when specifying an invalid disk label type.