### PR TITLE
Fix: correct name of package for qemu-debootstrap

### DIFF
--- a/README
+++ b/README
@@ -53,7 +53,7 @@ The following tools are used by vmdb2 (Debian package names in brackets).
 * `kpartx` [kpartx, mkpart command]
 * `parted` [`parted`, mklabel command]
 * `qemu-img` [`qemu-utils`, mkimg command]
-* `qemu-user-static` [`qemu-debootstrap`, qemu-debootstrap command]
+* `qemu-user-static` [`qemu-user-static`, qemu-debootstrap command]
 
 The following Python modules are used by vmdb2 (Debian package names in brackets).
 


### PR DESCRIPTION
Trivial fix as noted, closes #9.