### PR TITLE
Fix: encode ansible inventory before writing

### DIFF
--- a/vmdb/plugins/ansible_plugin.py
+++ b/vmdb/plugins/ansible_plugin.py
@@ -63,6 +63,6 @@ class AnsibleStepRunner(vmdb.StepRunnerInterface):
 
     def create_inventory(self, chroot):
         fd, filename = tempfile.mkstemp()
-        os.write(fd, '[image]\n{}\n'.format(chroot))
+        os.write(fd, '[image]\n{}\n'.format(chroot).encode())
         os.close(fd)
         return filename


### PR DESCRIPTION
os.write needs to be given encoded bytes rather than a unicode string.

This PR _should_ be enough to fix the ansible plugin for Python 3.

Closes #8.