### PR TITLE
Fix: require a spec file on command line

### DIFF
--- a/vmdb/app.py
+++ b/vmdb/app.py
@@ -42,6 +42,9 @@ class Vmdb2(cliapp.Application):
         self.step_runners = vmdb.StepRunnerList()
 
     def process_args(self, args):
+        if len(args) != 1:
+            sys.exit("No image specification was given on the command line.")
+
         vmdb.set_verbose_progress(self.settings['verbose'])
 
         spec = self.load_spec_file(args[0])


### PR DESCRIPTION
There may well be a way to mark the argument as mandatory within cliapp and let the option parser deal with this case, or there may be some other way of dealing with the lack of a spec file on the command line.

This is one possible way that would close #4 ...