### PR TITLE
Fix runcmd_chroot: actually specify chroot

### DIFF
--- a/vmdb/runcmd.py
+++ b/vmdb/runcmd.py
@@ -54,7 +54,7 @@ def runcmd(argv, *argvs, **kwargs):
 
 
 def runcmd_chroot(chroot, argv, *argvs, **kwargs):
-    full_argv = ['chroot'] + argv
+    full_argv = ['chroot', chroot] + argv
     return runcmd(full_argv, *argvs, **kwargs)
 
 


### PR DESCRIPTION
This change fixes image builds for me, which previously failed at the apt plugin step.