### PR TITLE
mkpart: add fs-type property

### DIFF
--- a/vmdb/plugins/partition_plugin.py
+++ b/vmdb/plugins/partition_plugin.py
@@ -54,11 +54,12 @@ class MkpartStepRunner(vmdb.StepRunnerInterface):
         start = step['start']
         end = step['end']
         part_tag = step['part-tag']
+        fs_type = step.get('fs-type', 'ext2')
 
         vmdb.progress(
             'Creating partition ({}) on {} ({} to {})'.format(
                 part_type, device, start, end))
-        vmdb.runcmd(['parted', '-s', device, 'mkpart', part_type, start, end])
+        vmdb.runcmd(['parted', '-s', device, 'mkpart', part_type, fs_type, start, end])
 
         vmdb.runcmd(['kpartx', '-dsv', device])
         output = vmdb.runcmd(['kpartx', '-asv', device]).decode('UTF-8')


### PR DESCRIPTION
The Raspberry Pi 3 bootloader requires the partition type to be fat32, otherwise it won’t boot.