### PR TITLE
twice  depend qemu-utils

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,12 @@
 vmdb2 (0.11+git-1) UNRELEASED; urgency=medium
 
+  [ Lars Wirzenius ]
   * New upstream version.
   * debian/copyright: Added Stuart.
-  * debian/control: Updated Homepage, patch from Geert Stappers.
+
+  [ Geert Stappers ]
+  * debian/control: Updated Homepage
+  * debian/control: Depend on qemu-utils
 
  -- Lars Wirzenius <liw@liw.fi>  Sat, 10 Feb 2018 17:56:43 +0200
 

--- a/debian/control
+++ b/debian/control
@@ -27,6 +27,7 @@ Depends: ${python3:Depends}, ${misc:Depends},
   cmdtest,
   debootstrap,
   parted,
+  qemu-utils,
   kpartx
 Recommends: ansible
 Description: creator of disk images with Debian installed


### PR DESCRIPTION
One for the actual change in debian/control,
the other debian/changelog.