### PR TITLE
chroot_plugin: use sh -e to fail broken shell scripts

### DIFF
--- a/vmdb/plugins/chroot_plugin.py
+++ b/vmdb/plugins/chroot_plugin.py
@@ -44,7 +44,7 @@ class ChrootStepRunner(vmdb.StepRunnerInterface):
 
         vmdb.progress(
             'chroot {} to {}'.format(mount_point, ' '.join(shell.split('\n'))))
-        vmdb.runcmd_chroot(mount_point, ['sh', '-c', shell])
+        vmdb.runcmd_chroot(mount_point, ['sh', '-e', '-c', shell])
 
 
 class ShellStepRunner(vmdb.StepRunnerInterface):
@@ -60,4 +60,4 @@ class ShellStepRunner(vmdb.StepRunnerInterface):
             'run shell {}'.format(' '.join(shell.split('\n'))))
         env = dict(os.environ)
         env['ROOT'] = state.mounts[fs_tag]
-        vmdb.runcmd(['sh', '-c', shell], env=env)
+        vmdb.runcmd(['sh', '-e', '-c', shell], env=env)


### PR DESCRIPTION
If a command failed in a shell step, any following commands would proceed as if nothing happened and the step would succeed. It was puzzling.