### PR TITLE
grub_plugin: 'defaults' and 'cmdline' options

### DIFF
--- a/vmdb/plugins/grub_plugin.py
+++ b/vmdb/plugins/grub_plugin.py
@@ -147,6 +147,12 @@ class GrubStepRunner(vmdb.StepRunnerInterface):
             'quiet',
             'systemd.show_status=false',
         ]
+        user_kernel_params = step.get('cmdline', '-')
+        if user_kernel_params == '':
+            kernel_params = []
+        elif user_kernel_params != '-':
+            kernel_params = user_kernel_params.split()
+
         if console == 'serial':
             kernel_params.extend([
                 'quiet',
@@ -157,7 +163,9 @@ class GrubStepRunner(vmdb.StepRunnerInterface):
                 'console=ttyS0,115200n8',
             ])
 
-        self.set_grub_cmdline_config(chroot, kernel_params)
+        if len(kernel_params) > 0:
+            self.set_grub_cmdline_config(chroot, kernel_params)
+
         if console == 'serial':
             self.add_grub_serial_console(chroot)
 


### PR DESCRIPTION
Options to append to /etc/default/grub (disable os-prober) and set GRUB_CMDLINE_LINIX_DEFAULT (force init=/lib/systemd/systemd), respectively.